### PR TITLE
Clean Up the Portfolio and Blog single page, remove the extra return

### DIFF
--- a/pages/blogs/[slug].jsx
+++ b/pages/blogs/[slug].jsx
@@ -82,11 +82,9 @@ export const getStaticProps = async ({params}) => {
 export const getStaticPaths = async () => {
 
 	const res = await client.getEntries({ content_type: 'jtiBlogs'})
-	const paths = res.items.map(item => {
-		return {
+	const paths = res.items.map(item => ({
 			params: { slug: item.fields.slug }
-		}
-	})
+	}))
 
 	return {
 		paths,

--- a/pages/portfolios/[slug].jsx
+++ b/pages/portfolios/[slug].jsx
@@ -95,11 +95,9 @@ export const getStaticProps = async ({params}) => {
 export const getStaticPaths = async () => {
 
 	const res = await client.getEntries({ content_type: 'jtiPortfolios'})
-	const paths = res.items.map(item => {
-		return {
+	const paths = res.items.map(item => ({
 			params: { slug: item.fields.slug }
-		}
-	})
+	}))
 
 	return {
 		paths,


### PR DESCRIPTION
Remove the extra return {} block from getStaticPaths from Portfolio and Blog single pages